### PR TITLE
Fix date formatting bug

### DIFF
--- a/src/app/reactjs/reminders-app/src/app/api/index.test.ts
+++ b/src/app/reactjs/reminders-app/src/app/api/index.test.ts
@@ -29,7 +29,7 @@ describe('API functions', () => {
     title: 'Test Reminder',
     description: 'This is a test reminder',
     limitDate: '2022-01-01',
-    limitDateFormatted: '2021-12-31',
+    limitDateFormatted: '2022-01-01',
     isDone: false,
     isDoneFormatted: 'No',
   };

--- a/src/app/reactjs/reminders-app/src/app/api/index.ts
+++ b/src/app/reactjs/reminders-app/src/app/api/index.ts
@@ -8,9 +8,9 @@ const headers = {
 
 const formatDate = (dateString: string) => {
   const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = ('0' + (date.getMonth() + 1)).slice(-2); // Months are 0-indexed in JavaScript
-  const day = ('0' + date.getDate()).slice(-2);
+  const year = date.getUTCFullYear();
+  const month = ('0' + (date.getUTCMonth() + 1)).slice(-2);
+  const day = ('0' + date.getUTCDate()).slice(-2);
   return `${year}-${month}-${day}`;
 };
 


### PR DESCRIPTION
## Summary
- avoid timezone shifting in `formatDate`
- update expected `limitDateFormatted` in tests

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68573cbc8bc8833396d4f29917fada3e